### PR TITLE
fix: improve themes

### DIFF
--- a/files/themes.json
+++ b/files/themes.json
@@ -62,5 +62,101 @@
       "link": "#58a6ff",
       "danger": "#ff6b6b"
     }
+  },
+  "catppuccin": {
+    "light": {
+      "canvas": "#eff1f5",
+      "border": "#dce0e8",
+      "text": "#4c4f69",
+      "link": "#1e66f5",
+      "danger": "#d20f39"
+    },
+    "dark": {
+      "canvas": "#1e1e2e",
+      "border": "#11111b",
+      "text": "#cdd6f4",
+      "link": "#89b4fa",
+      "danger": "#f38ba8"
+    }
+  },
+  "gruvbox": {
+    "light": {
+      "canvas": "#fbf1c7",
+      "border": "#d5c4a1",
+      "text": "#3c3836",
+      "link": "#076678",
+      "danger": "#b57614"
+    },
+    "dark": {
+      "canvas": "#282828",
+      "border": "#504945",
+      "text": "#ebdbb2",
+      "link": "#83a598",
+      "danger": "#d79921"
+    }
+  },
+  "nord": {
+    "light": {
+      "canvas": "#eceff4",
+      "border": "#d8dee9",
+      "text": "#4c566a",
+      "link": "#5e81ac",
+      "danger": "#bf616a"
+    },
+    "dark": {
+      "canvas": "#2e3440",
+      "border": "#434c5e",
+      "text": "#d8dee9",
+      "link": "#88c0d0",
+      "danger": "#bf616a"
+    }
+  },
+  "one_dark": {
+    "light": {
+      "canvas": "#fafafa",
+      "border": "#e5e5e6",
+      "text": "#383a42",
+      "link": "#4078f2",
+      "danger": "#e45649"
+    },
+    "dark": {
+      "canvas": "#282c34",
+      "border": "#3e4451",
+      "text": "#abb2bf",
+      "link": "#61afef",
+      "danger": "#e06c75"
+    }
+  },
+  "solarized": {
+    "light": {
+      "canvas": "#fdf6e3",
+      "border": "#eee8d5",
+      "text": "#657b83",
+      "link": "#268bd2",
+      "danger": "#b58900"
+    },
+    "dark": {
+      "canvas": "#002b36",
+      "border": "#073642",
+      "text": "#839496",
+      "link": "#268bd2",
+      "danger": "#b58900"
+    }
+  },
+  "tokyo_night": {
+    "light": {
+      "canvas": "#e1e2e7",
+      "border": "#d7d8de",
+      "text": "#6172b0",
+      "link": "#2e7de9",
+      "danger": "#f52a65"
+    },
+    "dark": {
+      "canvas": "#1a1b26",
+      "border": "#292e42",
+      "text": "#a9b1d6",
+      "link": "#7aa2f7",
+      "danger": "#f7768e"
+    }
   }
 }

--- a/gh_profile_repo_pins/repo_pins_enum.py
+++ b/gh_profile_repo_pins/repo_pins_enum.py
@@ -71,7 +71,13 @@ class RepoPinsImgThemeName(Enum):
     GITHUB = "github"
     GITHUB_SOFT = "github_soft"
     BG_IMG_CONTRAST = "bg_img_contrast"
+    CATPPUCCIN = "catppuccin"
     DRACULA = "dracula"
+    GRUVBOX = "gruvbox"
+    NORD = "nord"
+    ONE_DARK = "one_dark"
+    SOLARIZED = "solarized"
+    TOKYO_NIGHT = "tokyo_night"
 
 
 class RepoPinsImgThemeMode(Enum):


### PR DESCRIPTION
Fixes #1

Added 6 new light/dark themes (catppuccin, gruvbox, nord, one_dark, solarized, tokyo_night) to files/themes.json and registered them in the RepoPinsImgThemeName enum in gh_profile_repo_pins/repo_pins_enum.py, per the issue's instruction to improve theme coverage.

No local test suite detected.

---
This change was prepared with AI assistance under human direction and review.